### PR TITLE
Add PAT Authentication for http git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,43 @@
 [![Release](https://img.shields.io/github/release/fhopfensperger/git-remote-cleanup.svg?style=flat-square)](https://github.com//fhopfensperger/git-remote-cleanup/releases/latest)
 
 
-Get and delete no longer needed branches from a remote repository.
+Get and delete no longer needed release branches from a remote repository.
 
-## Installation
+# Usage
 
-### Option 1 (script)
+## All commands and flags
+
+```bash
+Available Commands:
+  branches    Get remote branches
+  delete      Delete old branches, keeps every latest patch version
+  help        Help about any command
+
+Flags:
+  -f, --file string     Uses repos from file (one repo per line)
+  -b, --filter string   Which branches should be filtered e.g. release
+  -h, --help            help for git-remote-cleanup
+  -p, --pat string      Use a Git Personal Access Token instead of the default private certificate! You could also set a environment variable. "export PAT=123456789" 
+  -r, --repos strings   Git Repo urls e.g. git@github.com:fhopfensperger/my-repo.git
+  -v, --version         version for git-remote-cleanup
+```
+
+Note: All flags can be set using environment variables, for example:
+```bash
+export REPOS=git@github.com:fhopfensperger/my-repo.git
+export PAT=1234567890abcdef
+...
+```
+
+# Installation
+
+## Option 1 (script)
 
 ```bash
 curl https://raw.githubusercontent.com/fhopfensperger/git-remote-cleanup/master/get.sh | bash
 ```
 
-### Option 2 (manually)
+## Option 2 (manually)
 
 Go to [Releases](https://github.com/fhopfensperger/git-remote-cleanup/releases) download the latest release according to your processor architecture and operating system, then unarchive and copy it to the right location
 

--- a/cmd/branches.go
+++ b/cmd/branches.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"github.com/fhopfensperger/git-remote-cleanup/pkg"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,9 +31,13 @@ var branchCmd = &cobra.Command{
 	Short: "Get remote branches",
 	Long:  `Get remote branches`,
 	Run: func(cmd *cobra.Command, args []string) {
+		auth := http.BasicAuth{
+			Username: "123", // Using a PAT this can be anything except an empty string
+			Password: pat,
+		}
 		for _, r := range repos {
 			latest = viper.GetBool("latest")
-			gitService := pkg.RemoteBranch{}
+			gitService := pkg.New(nil, &auth)
 			gitService.GetRemoteBranches(r, filter, latest)
 		}
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"github.com/fhopfensperger/git-remote-cleanup/pkg"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -31,10 +32,14 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete old branches, keeps every latest hotfix version",
 	Long:  `Delete old branches, keeps every latest hotfix version`,
 	Run: func(cmd *cobra.Command, args []string) {
+		auth := http.BasicAuth{
+			Username: "123", // Using a PAT this can be anything except an empty string
+			Password: pat,
+		}
 		excludes = viper.GetStringSlice("exclude")
 		dryRun = viper.GetBool("dry-run")
 		for _, r := range repos {
-			gitService := pkg.RemoteBranch{}
+			gitService := pkg.New(nil, &auth)
 			branches := gitService.GetRemoteBranches(r, filter, false)
 			branches = pkg.FilterBranches(branches)
 			gitService.CleanBranches(branches, excludes, dryRun)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 var repos []string
 var filter string
 var fileName string
+var pat string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -61,13 +62,16 @@ func init() {
 	pf.StringSliceP("repos", "r", []string{}, "Git Repo urls e.g. git@github.com:fhopfensperger/my-repo.git")
 	_ = viper.BindPFlag("repos", pf.Lookup("repos"))
 	//cobra.MarkFlagRequired(pf, "repos")
-	pf.StringP("branch-filter", "b", "", "Which branches should be filtered e.g. release")
-	_ = viper.BindPFlag("branch-filter", pf.Lookup("branch-filter"))
+	pf.StringP("filter", "b", "", "Which branches should be filtered e.g. release")
+	_ = viper.BindPFlag("filter", pf.Lookup("filter"))
 	_ = cobra.MarkFlagRequired(pf, "branch-filter")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	pf.StringP("file", "f", "", "Uses repos from file (one repo per line)")
 	_ = viper.BindPFlag("file", pf.Lookup("file"))
+	pf.StringP("pat", "p", "", `Use a Git Personal Access Token instead of the default private certificate! You could also set a environment variable. "export PAT=123456789" `)
+	_ = viper.BindPFlag("pat", pf.Lookup("pat"))
+
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.SetVersionTemplate(`{{printf "v%s\n" .Version}}`)
 }
@@ -78,8 +82,9 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	repos = viper.GetStringSlice("repos")
-	filter = viper.GetString("branch-filter")
+	filter = viper.GetString("filter")
 	fileName = viper.GetString("file")
+	pat = viper.GetString("pat")
 
 	if fileName != "" {
 		repos = getReposFromFile(fileName)

--- a/pkg/remote_branch_test.go
+++ b/pkg/remote_branch_test.go
@@ -121,7 +121,7 @@ func TestGetRemoteBranches(t *testing.T) {
 	ref4 := plumbing.NewHashReference(("refs/heads/release/v1.0.0"), plumbing.Hash{})
 	ref5 := plumbing.NewHashReference(("refs/heads/release/v11.0.0"), plumbing.Hash{})
 
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	remote.On("List", &git.ListOptions{}).Return([]*plumbing.Reference{ref, ref2, ref3, ref4, ref5}, nil)
 
@@ -145,7 +145,7 @@ func TestGetRemoteBranches_latest(t *testing.T) {
 	// Dummy it would never happen in a real repository
 	ref6 := plumbing.NewHashReference(("refs/heads/release/v11.0.0"), plumbing.Hash{})
 
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	remote.On("List", &git.ListOptions{}).Return([]*plumbing.Reference{ref1, ref2, ref3, ref4, ref5, ref6}, nil)
 
@@ -159,7 +159,7 @@ func TestGetRemoteBranches_latest(t *testing.T) {
 func TestGetRemoteBranchesNoBranchFilter(t *testing.T) {
 	if os.Getenv("FLAG") == "1" {
 		remote := new(remoteBranchMock)
-		mockRemoteBranch := New(remote)
+		mockRemoteBranch := New(remote, nil)
 		mockRemoteBranch.GetRemoteBranches("https://github.com/fhopfensperger/amqp-sb-client.git", "", false)
 		return
 	}
@@ -184,7 +184,7 @@ func TestRemoteBranch_CleanBranches(t *testing.T) {
 		URLs:  []string{"https://github.com/fhopfensperger/amqp-sb-client.git"},
 		Fetch: nil,
 	}
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	var refspecs []config.RefSpec
 	refspecs = append(refspecs, "refs/heads/release/v2.2.2:refs/heads/release/v2.2.2")
@@ -208,7 +208,7 @@ func TestRemoteBranch_CleanBranches_All_Excluded(t *testing.T) {
 		URLs:  []string{"https://github.com/fhopfensperger/amqp-sb-client.git"},
 		Fetch: nil,
 	}
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	var refspecs []config.RefSpec
 	refspecs = append(refspecs, "refs/heads/release/v2.2.2:refs/heads/release/v2.2.2")
@@ -233,7 +233,7 @@ func TestRemoteBranch_CleanBranches_Some_Excluded(t *testing.T) {
 		URLs:  []string{"https://github.com/fhopfensperger/amqp-sb-client.git"},
 		Fetch: nil,
 	}
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	var refspecs []config.RefSpec
 	refspecs = append(refspecs, "refs/heads/release/v2.2.2:refs/heads/release/v2.2.2")
@@ -258,7 +258,7 @@ func TestRemoteBranch_CleanBranches_branches_to_delete_empty(t *testing.T) {
 		URLs:  []string{"https://github.com/fhopfensperger/amqp-sb-client.git"},
 		Fetch: nil,
 	}
-	mockRemoteBranch := New(remote)
+	mockRemoteBranch := New(remote, nil)
 
 	var refspecs []config.RefSpec
 	refspecs = append(refspecs, "refs/heads/release/v2.2.2:refs/heads/release/v2.2.2")


### PR DESCRIPTION
Because:
- Security
- For clients where no ssh/git private cert is available

Signed-off-by: Florian Hopfensperger <f.hopfensperger@gmail.com>